### PR TITLE
Switch from Zod to SuperStruct

### DIFF
--- a/modules/getStockQuote.ts
+++ b/modules/getStockQuote.ts
@@ -1,6 +1,6 @@
-import * as z from 'https://cdn.skypack.dev/zod@3.5.1';
+import * as z from 'https://cdn.skypack.dev/superstruct';
 
-//#region Zod Object Definitions:
+//#region Superstruct Object Definitions:
 
 export const StockDataSchema = z.object( {
     "companySymbol": z.string(),
@@ -8,21 +8,21 @@ export const StockDataSchema = z.object( {
     "quote": z.number(),
     "timeOfQuote": z.string(),
 } );
-export type StockData = z.infer<typeof StockDataSchema>;
+export type StockData = z.Infer<typeof StockDataSchema>;
 
 export const ErrorDataSchema = z.object( {
     "code": z.number(),
     "message": z.string(),
     "status": z.string(),
 } );
-export type ErrorData = z.infer<typeof ErrorDataSchema>;
+export type ErrorData = z.Infer<typeof ErrorDataSchema>;
 
 export const ReturnedStockDataSchema = z.object( {
     "stockData": StockDataSchema,
     "errorData": ErrorDataSchema,
     "error": z.boolean(),
 } );
-export type ReturnedStockData = z.infer<typeof ReturnedStockDataSchema>;
+export type ReturnedStockData = z.Infer<typeof ReturnedStockDataSchema>;
 
 //#endregion
 
@@ -49,13 +49,17 @@ export async function getStockQuote( symbolToUse : string )
         }
       
         let responseText = await response.text();
-        return ( ReturnedStockDataSchema.parse( JSON.parse( responseText ) ) );
+
+        // this assert will throw an error if the responseText is not the correct shape
+        z.assert( JSON.parse( responseText ), ReturnedStockDataSchema );
+
+        return ( JSON.parse( responseText ) );
     }
     catch ( error )
     {
-        if ( error instanceof z.ZodError )
+        if ( error instanceof z.StructError )
         {
-            console.log( error.issues );
+            console.log( error.message );
         }
         throw error;
     }

--- a/modules/getTimeSeriesQuote.ts
+++ b/modules/getTimeSeriesQuote.ts
@@ -1,20 +1,20 @@
-import * as z from 'https://cdn.skypack.dev/zod@3.5.1';
+import * as z from 'https://cdn.skypack.dev/superstruct';
 
 
-//#region Zod Object Definitions:
+//#region Superstruct Object Definitions:
 
 export const StockDatumSchema = z.object( {
     "x": z.string(),
     "y": z.number(),
 } );
-export type StockDatum = z.infer<typeof StockDatumSchema>;
+export type StockDatum = z.Infer<typeof StockDatumSchema>;
 
 export const ErrorDataSchema = z.object( {
     "code": z.number(),
     "message": z.string(),
     "status": z.string(),
 } );
-export type ErrorData = z.infer<typeof ErrorDataSchema>;
+export type ErrorData = z.Infer<typeof ErrorDataSchema>;
 
 export const TwelveDataTimeSeriesSchema = z.object( {
     "stockData": z.array( StockDatumSchema ),
@@ -22,7 +22,7 @@ export const TwelveDataTimeSeriesSchema = z.object( {
     "error": z.boolean(),
 } );
 
-export type TimeSeriesStockData = z.infer<typeof TwelveDataTimeSeriesSchema>;
+export type TimeSeriesStockData = z.Infer<typeof TwelveDataTimeSeriesSchema>;
 
 //#endregion
 
@@ -50,14 +50,17 @@ export async function getTimeSeries( symbolToUse : string )
         }
 
         let responseText = await response.text();
-        console.log( responseText );
-        return ( TwelveDataTimeSeriesSchema.parse( JSON.parse( responseText ) ) );
+
+        // this assert will throw an error if the responseText is not the correct shape
+        z.assert( JSON.parse( responseText ), TwelveDataTimeSeriesSchema );
+
+        return ( JSON.parse( responseText ) );
     }
     catch ( error )
     {
-        if ( error instanceof z.ZodError )
+        if ( error instanceof z.StructError )
         {
-            console.log( error.issues );
+            console.log( error.message );
         }
         throw error;
     }

--- a/out/modules/getStockQuote.js
+++ b/out/modules/getStockQuote.js
@@ -7,8 +7,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import * as z from 'https://cdn.skypack.dev/zod@3.5.1';
-//#region Zod Object Definitions:
+import * as z from 'https://cdn.skypack.dev/superstruct';
+//#region Superstruct Object Definitions:
 export const StockDataSchema = z.object({
     "companySymbol": z.string(),
     "companyName": z.string(),
@@ -43,11 +43,13 @@ export function getStockQuote(symbolToUse) {
                 throw new Error(`HTTP error: ${response.status}`);
             }
             let responseText = yield response.text();
-            return (ReturnedStockDataSchema.parse(JSON.parse(responseText)));
+            // this assert will throw an error if the responseText is not the correct shape
+            z.assert(JSON.parse(responseText), ReturnedStockDataSchema);
+            return (JSON.parse(responseText));
         }
         catch (error) {
-            if (error instanceof z.ZodError) {
-                console.log(error.issues);
+            if (error instanceof z.StructError) {
+                console.log(error.message);
             }
             throw error;
         }

--- a/out/modules/getTimeSeriesQuote.js
+++ b/out/modules/getTimeSeriesQuote.js
@@ -7,8 +7,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import * as z from 'https://cdn.skypack.dev/zod@3.5.1';
-//#region Zod Object Definitions:
+import * as z from 'https://cdn.skypack.dev/superstruct';
+//#region Superstruct Object Definitions:
 export const StockDatumSchema = z.object({
     "x": z.string(),
     "y": z.number(),
@@ -42,12 +42,13 @@ export function getTimeSeries(symbolToUse) {
                 throw new Error(`HTTP error: ${response.status}`);
             }
             let responseText = yield response.text();
-            console.log(responseText);
-            return (TwelveDataTimeSeriesSchema.parse(JSON.parse(responseText)));
+            // this assert will throw an error if the responseText is not the correct shape
+            z.assert(JSON.parse(responseText), TwelveDataTimeSeriesSchema);
+            return (JSON.parse(responseText));
         }
         catch (error) {
-            if (error instanceof z.ZodError) {
-                console.log(error.issues);
+            if (error instanceof z.StructError) {
+                console.log(error.message);
             }
             throw error;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "zod": "^3.21.4"
+        "superstruct": "^1.0.3"
       }
     },
-    "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+    "node_modules/superstruct": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
+      "integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zod": "^3.21.4"
+    "superstruct": "^1.0.3"
   }
 }

--- a/types/skypack.d.ts
+++ b/types/skypack.d.ts
@@ -2,6 +2,6 @@
 declare module 'https://*';
 
 // Second, list out all your dependencies. For every URL, you must map it to its local module.
-declare module 'https://cdn.skypack.dev/zod@3.5.1' {
-    export * from 'zod';
+declare module 'https://cdn.skypack.dev/superstruct' {
+    export * from 'superstruct';
 }


### PR DESCRIPTION
Fixes #3

Summary:  Modified files which referenced Zod to now use SuperStruct.
Most changes were straight-up replacements, with a case-change for Infer.
However, Superstruct uses an Assert rather than Parse.
Note - I kept the alias as 'z' to make it obvious how few
changes were needed.