### PR TITLE
Use Minimal Versions of SuperStruct from Skypack

### DIFF
--- a/modules/getStockQuote.ts
+++ b/modules/getStockQuote.ts
@@ -1,4 +1,4 @@
-import * as z from 'https://cdn.skypack.dev/superstruct';
+import * as z from 'https://cdn.skypack.dev/pin/superstruct@v1.0.3-yP8v6jYc8g9oW4NL2673/mode=imports,min/optimized/superstruct.js';
 
 //#region Superstruct Object Definitions:
 

--- a/modules/getTimeSeriesQuote.ts
+++ b/modules/getTimeSeriesQuote.ts
@@ -1,4 +1,4 @@
-import * as z from 'https://cdn.skypack.dev/superstruct';
+import * as z from 'https://cdn.skypack.dev/pin/superstruct@v1.0.3-yP8v6jYc8g9oW4NL2673/mode=imports,min/optimized/superstruct.js';
 
 
 //#region Superstruct Object Definitions:

--- a/out/modules/getStockQuote.js
+++ b/out/modules/getStockQuote.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import * as z from 'https://cdn.skypack.dev/superstruct';
+import * as z from 'https://cdn.skypack.dev/pin/superstruct@v1.0.3-yP8v6jYc8g9oW4NL2673/mode=imports,min/optimized/superstruct.js';
 //#region Superstruct Object Definitions:
 export const StockDataSchema = z.object({
     "companySymbol": z.string(),

--- a/out/modules/getTimeSeriesQuote.js
+++ b/out/modules/getTimeSeriesQuote.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import * as z from 'https://cdn.skypack.dev/superstruct';
+import * as z from 'https://cdn.skypack.dev/pin/superstruct@v1.0.3-yP8v6jYc8g9oW4NL2673/mode=imports,min/optimized/superstruct.js';
 //#region Superstruct Object Definitions:
 export const StockDatumSchema = z.object({
     "x": z.string(),

--- a/types/skypack.d.ts
+++ b/types/skypack.d.ts
@@ -2,6 +2,6 @@
 declare module 'https://*';
 
 // Second, list out all your dependencies. For every URL, you must map it to its local module.
-declare module 'https://cdn.skypack.dev/superstruct' {
+declare module 'https://cdn.skypack.dev/pin/superstruct@v1.0.3-yP8v6jYc8g9oW4NL2673/mode=imports,min/optimized/superstruct.js' {
     export * from 'superstruct';
 }


### PR DESCRIPTION
Fixes #5

Summary: Simple changes to the import URLs to point to the min version.